### PR TITLE
Fix for #52

### DIFF
--- a/src/xref_runner.erl
+++ b/src/xref_runner.erl
@@ -219,7 +219,9 @@ find_function_source(M, F, A, Bin) ->
   {ok, {M, [{abstract_code, {raw_abstract_v1, Code}}]}} = AbstractCode,
 
   %% Extract the original source filename from the abstract code
-  [{attribute, 1, file, {Source, _}} | _] = Code,
+  [{_, _, _, {Source, _}} | _] = [E || E <- Code,
+             element(1, E) == attribute,
+             element(3, E) == file],
 
   %% Extract the line number for a given function def
   Fn = [E || E <- Code,


### PR DESCRIPTION
Iterate over code looking for first `file` attribute, ignoring everything else.
